### PR TITLE
Add podspec for CocoaPods support

### DIFF
--- a/unirest.podspec
+++ b/unirest.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "unirest"
+  s.version      = "0.0.1"
+  s.summary      = "Unirest is a set of lightweight HTTP libraries available in multiple languages."
+  s.homepage     = "http://github.com/mashape/unirest-obj-c"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Mark Palladino" => "mark@mashape.com" }
+  s.platform     = :ios, '5.0'
+  s.source       = { :git => "https://github.com/Mashape/unirest-obj-c.git", :commit => "b232eda2249537bae335c54b591bdb309da242be" }
+  s.source_files  = 'Unirest/*.{h,m}', 'Unirest/**/*.{h,m}'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Addresses issue #5 "Add support for CocoaPods".
I've tested this podspec on Xcode 5 under the iOS 7.0 sdk, and it builds with no errors.

You'll want to do the following before (or shortly after) merging:
1. Version the repo. I've pointed it at commit b232eda2249537bae335c54b591bdb309da242be (which is :HEAD at the moment) and called that 0.0.1. You may want to use a different versioning scheme, and instead of a commit, ideally it's pointed at a tag (change `:commit => "b232eda2249537bae335c54b591bdb309da242be"` to `:tag => '0.0.1'`).
2. Verify the authors. I wasn't sure who should be listed, so I just picked @thefosk who is the top contributor.
3. Chose deployment targets. Currently the spec says it's iOS 5.0, because ARC. Not sure if the library works under OS X, and what versions of iOS it's been tested with. Adding `s.ios.deployment_target = '5.0'` and `s.osx.deployment_target = '10.7'` specifies iOS and OS X support.

Hope to see you guys adopt CocoaPods for this project. It looks like a great resource, and I'll be interested to try it out and compare with AFNetworking, et al. :smile: 
